### PR TITLE
Fixed disconnect halt

### DIFF
--- a/src/Navarr/Socket/Server.php
+++ b/src/Navarr/Socket/Server.php
@@ -200,7 +200,7 @@ class Server
         unset($this->clients[$clientIndex]);
         unset($client);
 
-        if ($return === self::RETURN_HALT_SERVER) {
+        if ($return === false) {
             return false;
         }
 


### PR DESCRIPTION
The triggerHook function will check for self::RETURN_HALT_SERVER and return true or false
disconnect function should test if the return was false or true, not if the return was self::RETURN_HALT_SERVER.
